### PR TITLE
Fixed issue caused when multiple BMPs have been connected

### DIFF
--- a/source/.vscode/launch.json
+++ b/source/.vscode/launch.json
@@ -10,7 +10,7 @@
             "request": "launch",
             "program": "${workspaceFolder}/bmdebug.exe",
             "args": [],
-            "stopAtEntry": true,
+            "stopAtEntry": false,
             "cwd": "${workspaceFolder}",
             "environment": [],
             "externalConsole": false,

--- a/source/.vscode/launch.json
+++ b/source/.vscode/launch.json
@@ -1,0 +1,28 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Launch bmdebug.exe",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/bmdebug.exe",
+            "args": [],
+            "stopAtEntry": true,
+            "cwd": "${workspaceFolder}",
+            "environment": [],
+            "externalConsole": false,
+            "MIMode": "gdb",
+            "miDebuggerPath": "C:/Strawberry/c/bin/gdb.exe",
+            "setupCommands": [
+                {
+                    "description": "Enable pretty-printing for gdb",
+                    "text": "-enable-pretty-printing",
+                    "ignoreFailures": true
+                }
+            ]
+        }
+    ]
+}

--- a/source/Makefile.mingw
+++ b/source/Makefile.mingw
@@ -91,6 +91,8 @@ project : bmdebug.exe bmflash.exe bmtrace.exe bmscan.exe elf-postlink.exe traceg
 depend :
 	makedepend -b -fmakefile.dep $(OBJLIST_BMDEBUG:.o=.c) $(OBJLIST_BMFLASH:.o=.c) $(OBJLIST_BMTRACE:.o=.c)
 
+clean : 
+    $(Q)$(shell rm *.o, *.exe)
 
 ##### C files #####
 


### PR DESCRIPTION
The find_bmp method assumed only a single BMP had ever been connected to the computer. This PR fixes this issue.