### PR TITLE
Fixed bmp_attach null pointer issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The files that it concerns are:
 * winusb.h
 * winusbio.h
 
-The repository for this project contains the file `winusb.def`. You can use this file to create an import library for MingW using `dlltool`. The command line options to use are documented on top of the file `winusbdef`.
+The repository for this project contains the file `winusb.def`. You can use this file to create an import library for MingW using `dlltool`. The command line options to use are documented on top of the file `winusb.def`.
 The location of the header and library files for WinUSB can be set in `makefile.cfg`, see the `Makefile.mingw` for details.
 ### Windows with Visual C/C++
 The makefile for Visual C/C++ uses Microsoft's `nmake`, which is a bare-bones `make` clone. Generating the dependencies does not work yet at this moment.

--- a/source/bmtrace.c
+++ b/source/bmtrace.c
@@ -202,7 +202,7 @@ int main(void)
   struct nk_context *ctx;
   struct nk_image btn_folder;
   int canvas_width, canvas_height;
-  char mcu_driver[32];
+  char mcu_driver[32], mcu_arch[16];
   char txtConfigFile[256], findtext[128] = "", valstr[128] = "";
   char txtTSDLfile[256] = "";
   char cpuclock_str[15] = "", bitrate_str[15] = "";
@@ -280,7 +280,7 @@ int main(void)
       } else {
         int result = bmp_connect();
         if (result)
-          result = bmp_attach(2, mcu_driver, sizearray(mcu_driver), NULL, 0); //??? can check architecture: no SWO on Cortex-M0
+          result = bmp_attach(2, mcu_driver, sizearray(mcu_driver), mcu_arch, sizearray(mcu_arch)); //??? can check architecture: no SWO on Cortex-M0
         if (result) {
           unsigned long params[2];
           bmp_enabletrace((opt_mode == MODE_ASYNC) ? bitrate : 0);


### PR DESCRIPTION
Using an original BMP v2.1 connected to a SAM3X8C bmtrace crashes without any error messages.
A bit of debugging revealed it's caused by lack of null pointer checks in bmp-support.c:240 where it copies architecture into a null pointer.
This is a quick and dirty fix as I couldn't immediately see where the `arch != NULL` should be added. 