### PR TITLE
Fixed windows bmp trace guid scanning

### DIFF
--- a/source/bmscan.c
+++ b/source/bmscan.c
@@ -118,6 +118,11 @@ int find_bmp(int seqnr, int iface, TCHAR *name, size_t namelen)
     } else {
       /* read GUID */
       LSTATUS stat = RegQueryValueEx(hkeyItem, _T("DeviceInterfaceGUIDs"), NULL, NULL, (LPBYTE)portname, &maxlen);
+      /* continue scanning through the subkeys if we didn't find 'DeviceInterfaceGUIDs' in this one */
+      if(stat == ERROR_FILE_NOT_FOUND) {
+        idx_device++;
+        continue;
+      }
       /* ERROR_MORE_DATA is returned because there may technically be more GUIDs
          assigned to the device; we only care about the first one */
       if (stat != ERROR_SUCCESS && stat != ERROR_MORE_DATA) {


### PR DESCRIPTION
On my windows machine `find_bmp` fails with `TRACESTAT_NO_INTERFACE` because the first subkey in the registry doesn't contain the `somethingsomething/DeviceInterfaceGUIDs` regkey and it bails out before scanning the other subkeys.
This fixes that issue by continuing to scan the other subkeys.
My registry looks like this:
![image](https://user-images.githubusercontent.com/865977/67497056-ade01700-f67d-11e9-9778-4cef59a6f1bb.png)
Where `8&214b00d1&0&0005` (the second subkey) contains the expected `Device Parameters\DeviceInterfaceGUIDs` key while the other subkeys does not.