### PR TITLE
Command History Issue #36

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,21 @@ modules.order
 Module.symvers
 Mkfile.old
 dkms.conf
+
+# Editor temp files
+*~*
+
+# Linux Executable Files
+source/tracegen
+source/elf-postlink
+source/calltree
+source/bmtrace
+source/bmserial
+source/bmscan
+source/bmprofile
+source/bmflash
+source/bmdebug
+
+# Environment specific Make files
+source/Makefile
+source/makefile.cfg

--- a/source/.vscode/launch.json
+++ b/source/.vscode/launch.json
@@ -25,6 +25,26 @@
             ]
         },
         {
+            "name": "Linux bmdebug",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/bmdebug",
+            "args": [],
+            "stopAtEntry": true,
+            "cwd": "${workspaceFolder}",
+            "environment": [],
+            "externalConsole": false,
+            "MIMode": "gdb",
+            "miDebuggerPath": "gdb",
+            "setupCommands": [
+                {
+                    "description": "Enable pretty-printing for gdb",
+                    "text": "-enable-pretty-printing",
+                    "ignoreFailures": true
+                }
+            ]
+        },
+        {
             "name": "Launch bmtrace.exe",
             "type": "cppdbg",
             "request": "launch",


### PR DESCRIPTION
Hi,
Here are proposed modifications for issue #36 (command history not working).

When there was no prior command history (ex after a fresh install), the history was not initialized. => Corrected

Also, the command history functions a bit differently. All the commands are now stored in the order they were executed, except when the current command = the previous command. 
This helps to make the order of past commands more understandable. Previously, I would up-arrow expecting to see my last command, but it would show me a command that had been executed further back in the past.

Attached are a couple of example ini files that show the difference in how commands are stored.
In bmdebug-org-hist.ini.txt => all commands are stored only once, but the order of retrieval could be confusing.
In bmdebug-new-hist.ini.txt => all commands are stored in the order executed unless it is a repeat of the previous command.

[bmdebug-new-hist.ini.txt](https://github.com/compuphase/Black-Magic-Probe-Book/files/11040438/bmdebug-new-hist.ini.txt)
[bmdebug-org-hist.ini.txt](https://github.com/compuphase/Black-Magic-Probe-Book/files/11040439/bmdebug-org-hist.ini.txt)

Lastly,
A couple of files were updated for developing under Linux
.vscode/launch.json => added Linux debug config
.gitignore => ignores Linux binaries and Linux-specific make files
